### PR TITLE
Add newsletter link to footer quick links

### DIFF
--- a/components/layout/footer_links.json
+++ b/components/layout/footer_links.json
@@ -29,6 +29,10 @@
     {
       "url": "/art_gallery",
       "text": "Art Gallery"
+    },
+    {
+      "url": "/newsletter",
+      "text": "Newsletter"
     }
   ],
   "Other Useful Links": [


### PR DESCRIPTION
Added a Newsletter link under the Quick Links section in the footer, so users can navigate to the newsletter page directly from footer as well.